### PR TITLE
WIZ-11249 PHP 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "type": "library",
     "homepage": "https://github.com/wizaplace/semantic-versioning",
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.14",
-        "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit": "^8.0"
+        "friendsofphp/php-cs-fixer": "^3.8",
+        "phpstan/phpstan": "^1.6",
+        "phpunit/phpunit": "^7|^8|^9"
     },
     "license": "MIT",
     "authors": [
@@ -17,7 +17,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=7.4"
+        "php": "^7.4|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Version.php
+++ b/src/Version.php
@@ -14,40 +14,16 @@ namespace Wizaplace\SemanticVersioning;
  */
 class Version
 {
-    /**
-     * @var int
-     */
-    private $major;
+    private int $major;
 
-    /**
-     * @var int
-     */
-    private $minor;
+    private int $minor;
 
-    /**
-     * @var int
-     */
-    private $patch;
+    private int $patch;
 
-    /**
-     * @var string|null
-     */
-    private $prerelease;
+    private ?string $prerelease;
 
-    /**
-     * @var string|null
-     */
-    private $build;
+    private ?string $build;
 
-    /**
-     * Version constructor.
-     *
-     * @param int $major
-     * @param int $minor
-     * @param int $patch
-     * @param string|null $prerelease
-     * @param string|null $build
-     */
     public function __construct(int $major, int $minor, int $patch, ?string $prerelease = null, ?string $build = null)
     {
         $this->major = $major;
@@ -91,52 +67,42 @@ class Version
             return $this->patch <=> $value->patch;
         }
 
-        if (null === $this->prerelease or null === $value->prerelease) {
-            if (null === $this->prerelease and null === $value->prerelease) {
+        if (null === $this->prerelease || null === $value->prerelease) {
+            if (null === $this->prerelease && null === $value->prerelease) {
                 return 0;
             }
 
             return null === $this->prerelease ? 1 : -1;
         }
 
-        $comparison = array_filter(array_map(function ($a, $b): int {
-            if (is_numeric($a) && is_numeric($b)) {
-                return intval($a) <=> intval($b);
-            }
+        $comparison = \array_filter(
+            \array_map(function ($a, $b): int {
+                if (\is_numeric($a) && \is_numeric($b)) {
+                    return \intval($a) <=> \intval($b);
+                }
 
-            return $a <=> $b;
-        }, $this->getPrereleaseIdentifiers(), $value->getPrereleaseIdentifiers()));
+                return $a <=> $b;
+            }, $this->getPrereleaseIdentifiers(), $value->getPrereleaseIdentifiers())
+        );
 
-        return empty($comparison) ? 0 : reset($comparison);
+        return empty($comparison) ? 0 : \reset($comparison);
     }
 
-    /**
-     * @return int
-     */
     public function getMajor(): int
     {
         return $this->major;
     }
 
-    /**
-     * @return int
-     */
     public function getMinor(): int
     {
         return $this->minor;
     }
 
-    /**
-     * @return int
-     */
     public function getPatch(): int
     {
         return $this->patch;
     }
 
-    /**
-     * @return string|null
-     */
     public function getPrerelease(): ?string
     {
         return $this->prerelease;
@@ -147,12 +113,9 @@ class Version
      */
     public function getPrereleaseIdentifiers(): array
     {
-        return $this->prerelease ? explode('.', $this->prerelease) : [];
+        return $this->prerelease ? \explode('.', $this->prerelease) : [];
     }
 
-    /**
-     * @return string|null
-     */
     public function getBuild(): ?string
     {
         return $this->build;
@@ -163,6 +126,6 @@ class Version
      */
     public function getBuildIdentifiers(): array
     {
-        return $this->build ? explode('.', $this->build) : [];
+        return $this->build ? \explode('.', $this->build) : [];
     }
 }

--- a/src/VersionFactory.php
+++ b/src/VersionFactory.php
@@ -14,16 +14,12 @@ namespace Wizaplace\SemanticVersioning;
  */
 class VersionFactory
 {
-    const REGEXP_INTEGER = '(\d+)';
-    const REGEXP_DOT_SEPARATED_IDENTIFIERS = '([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)';
+    public const REGEXP_INTEGER = '(\d+)';
+    public const REGEXP_DOT_SEPARATED_IDENTIFIERS = '([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)';
 
-    /**
-     * @param string $versionString
-     * @return Version
-     */
     public static function fromString(string $versionString): Version
     {
-        $regexp = sprintf(
+        $regexp = \sprintf(
             '/^%s\.%s\.%s(?:\-%s)?(?:\+%s)?$/',
             self::REGEXP_INTEGER,
             self::REGEXP_INTEGER,
@@ -32,35 +28,31 @@ class VersionFactory
             self::REGEXP_DOT_SEPARATED_IDENTIFIERS
         );
 
-        if (1 !== preg_match($regexp, $versionString, $matches, PREG_UNMATCHED_AS_NULL)) {
+        if (1 !== \preg_match($regexp, $versionString, $matches, PREG_UNMATCHED_AS_NULL)) {
             throw new \RuntimeException('Version string does not follow semantic versioning: ' . $versionString);
         }
 
-        array_shift($matches);
+        \array_shift($matches);
 
-        return new Version(intval($matches[0]), intval($matches[1]), intval($matches[2]), $matches[3] ?? null, $matches[4] ?? null);
+        return new Version(
+            \intval($matches[0]),
+            \intval($matches[1]),
+            \intval($matches[2]),
+            $matches[3] ?? null,
+            $matches[4] ?? null
+        );
     }
 
-    /**
-     * @param Version $version
-     * @return Version
-     */
     public static function nextMajor(Version $version): Version
     {
         return new Version($version->getMajor() + 1, 0, 0);
     }
-    /**
-     * @param Version $version
-     * @return Version
-     */
+
     public static function nextMinor(Version $version): Version
     {
         return new Version($version->getMajor(), $version->getMinor() + 1, 0);
     }
-    /**
-     * @param Version $version
-     * @return Version
-     */
+
     public static function nextPatch(Version $version): Version
     {
         return new Version($version->getMajor(), $version->getMinor(), $version->getPatch() + 1);

--- a/tests/VersionFactoryTest.php
+++ b/tests/VersionFactoryTest.php
@@ -13,25 +13,31 @@ class VersionFactoryTest extends TestCase
 {
     public function testFromString()
     {
-        $this->assertEquals(new Version(1, 2, 3), VersionFactory::fromString('1.2.3'));
-        $this->assertEquals(new Version(1, 0, 0, 'alpha.1'), VersionFactory::fromString('1.0.0-alpha.1'));
-        $this->assertEquals(new Version(1, 0, 0, null, '20130313144700'), VersionFactory::fromString('1.0.0+20130313144700'));
-        $this->assertEquals(new Version(1, 0, 0, 'beta', 'exp.sha.5114f85'), VersionFactory::fromString('1.0.0-beta+exp.sha.5114f85'));
+        static::assertEquals(new Version(1, 2, 3), VersionFactory::fromString('1.2.3'));
+        static::assertEquals(new Version(1, 0, 0, 'alpha.1'), VersionFactory::fromString('1.0.0-alpha.1'));
+        static::assertEquals(
+            new Version(1, 0, 0, null, '20130313144700'),
+            VersionFactory::fromString('1.0.0+20130313144700')
+        );
+        static::assertEquals(
+            new Version(1, 0, 0, 'beta', 'exp.sha.5114f85'),
+            VersionFactory::fromString('1.0.0-beta+exp.sha.5114f85')
+        );
     }
 
     public function testNextMajor()
     {
-        $this->assertEquals(new Version(2, 0, 0), VersionFactory::nextMajor(new Version(1, 2, 3)));
+        static::assertEquals(new Version(2, 0, 0), VersionFactory::nextMajor(new Version(1, 2, 3)));
     }
 
     public function testNextMinor()
     {
-        $this->assertEquals(new Version(1, 3, 0), VersionFactory::nextMinor(new Version(1, 2, 3)));
+        static::assertEquals(new Version(1, 3, 0), VersionFactory::nextMinor(new Version(1, 2, 3)));
     }
 
     public function testNextPatch()
     {
-        $this->assertEquals(new Version(1, 2, 4), VersionFactory::nextPatch(new Version(1, 2, 3)));
+        static::assertEquals(new Version(1, 2, 4), VersionFactory::nextPatch(new Version(1, 2, 3)));
     }
 
     public function testFromStringEmpty()

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -13,81 +13,81 @@ class VersionTest extends TestCase
     public function testVersion()
     {
         $version = new Version(1, 2, 3);
-        $this->assertSame(1, $version->getMajor());
-        $this->assertSame(2, $version->getMinor());
-        $this->assertSame(3, $version->getPatch());
-        $this->assertNull($version->getPrerelease());
-        $this->assertSame([], $version->getPrereleaseIdentifiers());
-        $this->assertNull($version->getBuild());
-        $this->assertSame([], $version->getBuildIdentifiers());
-        $this->assertSame('1.2.3', $version->toString());
+        static::assertSame(1, $version->getMajor());
+        static::assertSame(2, $version->getMinor());
+        static::assertSame(3, $version->getPatch());
+        static::assertNull($version->getPrerelease());
+        static::assertSame([], $version->getPrereleaseIdentifiers());
+        static::assertNull($version->getBuild());
+        static::assertSame([], $version->getBuildIdentifiers());
+        static::assertSame('1.2.3', $version->toString());
     }
 
     public function testVersionPreRelease()
     {
         $version = new Version(1, 0, 0, 'alpha.1');
-        $this->assertSame(1, $version->getMajor());
-        $this->assertSame(0, $version->getMinor());
-        $this->assertSame(0, $version->getPatch());
-        $this->assertSame('alpha.1', $version->getPrerelease());
-        $this->assertSame(['alpha', '1'], $version->getPrereleaseIdentifiers());
-        $this->assertSame('1.0.0-alpha.1', $version->toString());
+        static::assertSame(1, $version->getMajor());
+        static::assertSame(0, $version->getMinor());
+        static::assertSame(0, $version->getPatch());
+        static::assertSame('alpha.1', $version->getPrerelease());
+        static::assertSame(['alpha', '1'], $version->getPrereleaseIdentifiers());
+        static::assertSame('1.0.0-alpha.1', $version->toString());
     }
 
     public function testVersionBuild()
     {
         $version = new Version(1, 0, 0, null, '20130313144700');
-        $this->assertSame(1, $version->getMajor());
-        $this->assertSame(0, $version->getMinor());
-        $this->assertSame(0, $version->getPatch());
-        $this->assertNull($version->getPrerelease());
-        $this->assertSame([], $version->getPrereleaseIdentifiers());
-        $this->assertSame('20130313144700', $version->getBuild());
-        $this->assertSame(['20130313144700'], $version->getBuildIdentifiers());
-        $this->assertSame('1.0.0+20130313144700', $version->toString());
+        static::assertSame(1, $version->getMajor());
+        static::assertSame(0, $version->getMinor());
+        static::assertSame(0, $version->getPatch());
+        static::assertNull($version->getPrerelease());
+        static::assertSame([], $version->getPrereleaseIdentifiers());
+        static::assertSame('20130313144700', $version->getBuild());
+        static::assertSame(['20130313144700'], $version->getBuildIdentifiers());
+        static::assertSame('1.0.0+20130313144700', $version->toString());
     }
 
     public function testVersionPrereleaseBuild()
     {
         $version = new Version(1, 0, 0, 'beta', 'exp.sha.5114f85');
-        $this->assertSame(1, $version->getMajor());
-        $this->assertSame(0, $version->getMinor());
-        $this->assertSame(0, $version->getPatch());
-        $this->assertSame('beta', $version->getPrerelease());
-        $this->assertSame(['beta'], $version->getPrereleaseIdentifiers());
-        $this->assertSame('exp.sha.5114f85', $version->getBuild());
-        $this->assertSame(['exp', 'sha', '5114f85'], $version->getBuildIdentifiers());
-        $this->assertSame('1.0.0-beta+exp.sha.5114f85', $version->toString());
+        static::assertSame(1, $version->getMajor());
+        static::assertSame(0, $version->getMinor());
+        static::assertSame(0, $version->getPatch());
+        static::assertSame('beta', $version->getPrerelease());
+        static::assertSame(['beta'], $version->getPrereleaseIdentifiers());
+        static::assertSame('exp.sha.5114f85', $version->getBuild());
+        static::assertSame(['exp', 'sha', '5114f85'], $version->getBuildIdentifiers());
+        static::assertSame('1.0.0-beta+exp.sha.5114f85', $version->toString());
     }
 
     public function testVersionEmptyString()
     {
         $version = new Version(1, 0, 0, '', '');
-        $this->assertSame(1, $version->getMajor());
-        $this->assertSame(0, $version->getMinor());
-        $this->assertSame(0, $version->getPatch());
-        $this->assertNull($version->getPrerelease());
-        $this->assertSame([], $version->getPrereleaseIdentifiers());
-        $this->assertNull($version->getBuild());
-        $this->assertSame([], $version->getBuildIdentifiers());
-        $this->assertSame('1.0.0', $version->toString());
+        static::assertSame(1, $version->getMajor());
+        static::assertSame(0, $version->getMinor());
+        static::assertSame(0, $version->getPatch());
+        static::assertNull($version->getPrerelease());
+        static::assertSame([], $version->getPrereleaseIdentifiers());
+        static::assertNull($version->getBuild());
+        static::assertSame([], $version->getBuildIdentifiers());
+        static::assertSame('1.0.0', $version->toString());
     }
 
     public function testCompareTo()
     {
-        $this->assertEquals(-1, (new Version(1, 0, 0))->compareTo(new Version(2, 0, 0)));
-        $this->assertEquals(-1, (new Version(2, 0, 0))->compareTo(new Version(2, 1, 0)));
-        $this->assertEquals(-1, (new Version(2, 1, 0))->compareTo(new Version(2, 1, 1)));
-        $this->assertEquals(-1, (new Version(1, 0, 0, 'alpha'))->compareTo(new Version(1, 0, 0)));
-        $this->assertEquals(0, (new Version(1, 0, 0))->compareTo(new Version(1, 0, 0)));
-        $this->assertEquals(0, (new Version(1, 0, 0, 'alpha'))->compareTo(new Version(1, 0, 0, 'alpha')));
-        $this->assertEquals(1, (new Version(1, 0, 0))->compareTo(new Version(1, 0, 0, 'alpha')));
-        $this->assertEquals(-1, (new Version(1, 0, 0, 'alpha'))->compareTo(new Version(1, 0, 0, 'alpha.1')));
-        $this->assertEquals(-1, (new Version(1, 0, 0, 'alpha.1'))->compareTo(new Version(1, 0, 0, 'alpha.beta')));
-        $this->assertEquals(-1, (new Version(1, 0, 0, 'alpha.beta'))->compareTo(new Version(1, 0, 0, 'beta')));
-        $this->assertEquals(-1, (new Version(1, 0, 0, 'beta'))->compareTo(new Version(1, 0, 0, 'beta.2')));
-        $this->assertEquals(-1, (new Version(1, 0, 0, 'beta.2'))->compareTo(new Version(1, 0, 0, 'beta.11')));
-        $this->assertEquals(-1, (new Version(1, 0, 0, 'beta.11'))->compareTo(new Version(1, 0, 0, 'rc.1')));
-        $this->assertEquals(-1, (new Version(1, 0, 0, 'rc.1'))->compareTo(new Version(1, 0, 0)));
+        static::assertEquals(-1, (new Version(1, 0, 0))->compareTo(new Version(2, 0, 0)));
+        static::assertEquals(-1, (new Version(2, 0, 0))->compareTo(new Version(2, 1, 0)));
+        static::assertEquals(-1, (new Version(2, 1, 0))->compareTo(new Version(2, 1, 1)));
+        static::assertEquals(-1, (new Version(1, 0, 0, 'alpha'))->compareTo(new Version(1, 0, 0)));
+        static::assertEquals(0, (new Version(1, 0, 0))->compareTo(new Version(1, 0, 0)));
+        static::assertEquals(0, (new Version(1, 0, 0, 'alpha'))->compareTo(new Version(1, 0, 0, 'alpha')));
+        static::assertEquals(1, (new Version(1, 0, 0))->compareTo(new Version(1, 0, 0, 'alpha')));
+        static::assertEquals(-1, (new Version(1, 0, 0, 'alpha'))->compareTo(new Version(1, 0, 0, 'alpha.1')));
+        static::assertEquals(-1, (new Version(1, 0, 0, 'alpha.1'))->compareTo(new Version(1, 0, 0, 'alpha.beta')));
+        static::assertEquals(-1, (new Version(1, 0, 0, 'alpha.beta'))->compareTo(new Version(1, 0, 0, 'beta')));
+        static::assertEquals(-1, (new Version(1, 0, 0, 'beta'))->compareTo(new Version(1, 0, 0, 'beta.2')));
+        static::assertEquals(-1, (new Version(1, 0, 0, 'beta.2'))->compareTo(new Version(1, 0, 0, 'beta.11')));
+        static::assertEquals(-1, (new Version(1, 0, 0, 'beta.11'))->compareTo(new Version(1, 0, 0, 'rc.1')));
+        static::assertEquals(-1, (new Version(1, 0, 0, 'rc.1'))->compareTo(new Version(1, 0, 0)));
     }
 }


### PR DESCRIPTION
Upgrade all dependencies to latest releases for PHP 8 compatibility.

Fix php-cs-fixer and reformat code.